### PR TITLE
fix templates in prebuilds (#1)

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -11,7 +11,7 @@ ports:
 
 tasks:
   - init: >
-      ( if [ ! -e "Main.hs" ]; then git init; git remote add ihp https://github.com/digitallyinduced/ihp-boilerplate.git; git fetch --all --prune; git rebase ihp/master; nix-shell -j auto --cores 0 --quiet --run 'make -s all .envrc; new-application Web'; fi) && nix-shell -j auto --cores 0 --run 'make -s all .envrc' && direnv allow
+      ( if [ ! -e "Main.hs" ]; then rm -rf /tmp/ihp-boilerplate; git clone https://github.com/digitallyinduced/ihp-boilerplate.git /tmp/ihp-boilerplate; rm -rf /tmp/ihp-boilerplate/.git; cp -r /tmp/ihp-boilerplate/. .; nix-shell -j auto --cores 0 --quiet --run 'make -s all .envrc; new-application Web'; fi) && nix-shell -j auto --cores 0 --run 'make -s all .envrc' && direnv allow
     command: >
       export IHP_BASEURL=`gp url 8000`;
       export IHP_IDE_BASEURL=`gp url 8001`;


### PR DESCRIPTION
use temporary git clone of boilerplate instead of multiple git remotes

## Description
When using gitpod prebuilds, the old template was broken. Now, instead of using multiple git remotes to fetch the latest ihp-boilerplate if it isn't fetched yet, the ihp-boilerplate is instead cloned into a temporary directory and all its contents are copied to the current workspace.

## Related Issue(s)
<!-- List the issue(s) this PR solves 
Fixes # -->

## How to test
<!-- Provide steps to test this PR -->
Create a new gitpod workspace using the state of this PR, making sure that a prebuild is utilized.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Fix creating the template from a prebuild.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
