### PR TITLE
fix IHP GitPod using newer version of Nix

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -18,7 +18,7 @@ ENV USER gitpod
 WORKDIR /home/gitpod
 
 RUN touch .bash_profile \
- && curl https://nixos.org/releases/nix/nix-2.3.14/install | sh
+ && curl https://nixos.org/releases/nix/nix-2.15.0/install | sh
 
 RUN echo '. /home/gitpod/.nix-profile/etc/profile.d/nix.sh' >> /home/gitpod/.bashrc
 RUN mkdir -p /home/gitpod/.config/nixpkgs && echo '{ allowUnfree = true; }' >> /home/gitpod/.config/nixpkgs/config.nix

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -2,6 +2,7 @@ FROM gitpod/workspace-nix
 
 # Make an empty IHP project to warm up the nix store
 RUN . /home/gitpod/.nix-profile/etc/profile.d/nix.sh \
+    && cachix use digitallyinduced \
     && git clone https://github.com/digitallyinduced/ihp-boilerplate.git /tmp/warmup \
     && cd /tmp/warmup \
     && (nix-shell -j auto --cores 0 --quiet --run 'echo ok' || true)

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,42 +1,4 @@
-# Based on https://github.com/gitpod-io/template-nix/blob/main/.gitpod.Dockerfile
-
-FROM gitpod/workspace-base
-
-USER root
-
-# Install Nix
-RUN addgroup --system nixbld \
-  && adduser gitpod nixbld \
-  && for i in $(seq 1 30); do useradd -ms /bin/bash nixbld$i &&  adduser nixbld$i nixbld; done \
-  && mkdir -m 0755 /nix && chown gitpod /nix \
-  && mkdir -p /etc/nix && echo 'sandbox = false' > /etc/nix/nix.conf
-  
-# Install Nix
-CMD /bin/bash -l
-USER gitpod
-ENV USER gitpod
-WORKDIR /home/gitpod
-
-RUN touch .bash_profile \
- && curl https://nixos.org/releases/nix/nix-2.15.0/install | sh
-
-RUN echo '. /home/gitpod/.nix-profile/etc/profile.d/nix.sh' >> /home/gitpod/.bashrc
-RUN mkdir -p /home/gitpod/.config/nixpkgs && echo '{ allowUnfree = true; }' >> /home/gitpod/.config/nixpkgs/config.nix
-
-# Install cachix
-RUN . /home/gitpod/.nix-profile/etc/profile.d/nix.sh \
-  && nix-env -iA cachix -f https://cachix.org/api/v1/install \
-  && cachix use cachix \
-  && cachix use digitallyinduced
-
-# Install git
-RUN . /home/gitpod/.nix-profile/etc/profile.d/nix.sh \
-  && nix-env -i git git-lfs
-
-# Install direnv
-RUN . /home/gitpod/.nix-profile/etc/profile.d/nix.sh \
-  && nix-env -i direnv \
-  && direnv hook bash >> /home/gitpod/.bashrc
+FROM gitpod/workspace-nix
 
 # Make an empty IHP project to warm up the nix store
 RUN . /home/gitpod/.nix-profile/etc/profile.d/nix.sh \


### PR DESCRIPTION
The older version of Nix has stopped working to install GHC. This PR fixes IHP GitPod support.