### PR TITLE
Update GitPod IHP template to work with latest IHP version

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -10,11 +10,20 @@ ports:
     onOpen: open-browser
 
 tasks:
-  - init: >
-      ( if [ ! -e "Main.hs" ]; then rm -rf /tmp/ihp-boilerplate; git clone https://github.com/digitallyinduced/ihp-boilerplate.git /tmp/ihp-boilerplate; rm -rf /tmp/ihp-boilerplate/.git; cp -r /tmp/ihp-boilerplate/. .; git add . && nix-shell -j auto --cores 0 --quiet --run 'make -s all; new-application Web'; fi) && direnv allow
-    command: >
-      export IHP_BASEURL=`gp url 8000`;
-      export IHP_IDE_BASEURL=`gp url 8001`;
+  - init: |
+      (
+        if [ ! -e "Main.hs" ]; then
+          rm -rf /tmp/ihp-boilerplate
+          git clone https://github.com/digitallyinduced/ihp-boilerplate.git /tmp/ihp-boilerplate
+          rm -rf /tmp/ihp-boilerplate/.git
+          cp -r /tmp/ihp-boilerplate/. .
+          git add . && nix-shell -j auto --cores 0 --quiet --run 'make -s all; new-application Web'
+        fi
+      ) && direnv allow
+
+    command: |
+      export IHP_BASEURL=`gp url 8000`
+      export IHP_IDE_BASEURL=`gp url 8001`
       ./start
 
 vscode:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -11,7 +11,7 @@ ports:
 
 tasks:
   - init: >
-      ( if [ ! -e "Main.hs" ]; then rm -rf /tmp/ihp-boilerplate; git clone https://github.com/digitallyinduced/ihp-boilerplate.git /tmp/ihp-boilerplate; rm -rf /tmp/ihp-boilerplate/.git; cp -r /tmp/ihp-boilerplate/. .; nix-shell -j auto --cores 0 --quiet --run 'make -s all .envrc; new-application Web'; fi) && nix-shell -j auto --cores 0 --run 'make -s all .envrc' && direnv allow
+      ( if [ ! -e "Main.hs" ]; then rm -rf /tmp/ihp-boilerplate; git clone https://github.com/digitallyinduced/ihp-boilerplate.git /tmp/ihp-boilerplate; rm -rf /tmp/ihp-boilerplate/.git; cp -r /tmp/ihp-boilerplate/. .; git add . && nix-shell -j auto --cores 0 --quiet --run 'make -s all; new-application Web'; fi) && direnv allow
     command: >
       export IHP_BASEURL=`gp url 8000`;
       export IHP_IDE_BASEURL=`gp url 8001`;


### PR DESCRIPTION
The latest IHP version has some breaking changes in the way the dev environment works.

Without this patch we get this error right now:

```
remote: Total 901 (delta 73), reused 62 (delta 60), pack-reused 814
Receiving objects: 100% (901/901), 301.34 KiB | 10.39 MiB/s, done.
Resolving deltas: 100% (481/481), done.
error: getting status of '/nix/store/2d74m5gmrjk3mr1npkynddak2nqj1q8r-source/flake.nix': No such file or directory
(use '--show-trace' to show detailed location information)
direnv: loading /workspace/template-ihp/.envrc
direnv: loading https://raw.githubusercontent.com/nix-community/nix-direnv/2.3.0/direnvrc (sha256-Dmd+j63L84wuzgyjITIfSxSD57Tx7v51DMxVZOsiUD8=)
direnv: using flake . --impure --accept-flake-config
error: getting status of '/nix/store/2d74m5gmrjk3mr1npkynddak2nqj1q8r-source/flake.nix': No such file or directory
error: getting status of '/workspace/template-ihp/.direnv/flake-profile.187': No such file or directory
error: getting status of '/nix/store/2d74m5gmrjk3mr1npkynddak2nqj1q8r-source/flake.nix': No such file or directory
direnv: nix-direnv: renewed cache
direnv: export +XDG_DATA_DIRS
```

With this patch, the GitPod IHP template should work without any errors again